### PR TITLE
Use nose setuptools integration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     entry_points={
         'console_scripts': ['gixy=gixy.cli.main:main'],
     },
+    test_suite='nose.collector',
     packages=find_packages(exclude=['tests', 'tests.*']),
     classifiers=[
         'Development Status :: 3 - Alpha',
@@ -37,5 +38,5 @@ setup(
         'Topic :: Software Development :: Quality Assurance',
         'Topic :: Software Development :: Testing'
     ],
-    include_package_data=True,
-    )
+    include_package_data=True
+)


### PR DESCRIPTION
https://nose.readthedocs.io/en/latest/setuptools_integration.html

[`tests_require`](https://ptpb.pw/RG9A.png) could be added, but I haven't seen a project use that.